### PR TITLE
Handle ETCd timeouts in large clusters

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -50,6 +50,8 @@ sudo mv goldilocks /usr/local/bin/
 
 This starts the goldilocks controller. Used by the Docker container, it will create vpas for properly labelled namespaces.
 
+The controller includes intelligent rate limiting and backoff mechanisms to handle etcd timeouts and control plane pressure automatically. When watch stream failures or API timeouts are detected, the controller implements exponential backoff to reduce load on the control plane.
+
 #### Flags
 You can set the default behavior for VPA creation using some flags. When specified, labels will always take precedence over the command line flags.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -92,3 +92,31 @@ This shows a healthy metrics service:
 NAME                     SERVICE                         AVAILABLE   AGE
 v1beta1.metrics.k8s.io   metrics-server/metrics-server   True        36s
 ```
+
+## I'm seeing etcd timeout errors or control plane pressure issues, what gives?
+
+If you're experiencing etcd timeouts or control plane pressure in large clusters, Goldilocks includes intelligent rate limiting and backoff mechanisms. These issues typically manifest as:
+
+* Watch stream connection failures
+* Context deadline exceeded errors
+* etcd server unavailable messages
+* Frequent informer restarts
+
+The controller automatically detects these conditions and implements exponential backoff (1s, 2s, 4s, 8s, 15s, 30s max) to reduce load on the control plane. You'll see log messages like:
+
+```
+CONTROL PLANE PRESSURE DETECTED: Recorded watch failure #2, will pause for 4s on next operation
+CONTROL PLANE BACKOFF: Pausing watcher startup for 4s due to control plane pressure
+```
+
+### Troubleshooting Control Plane Issues
+
+1. **Check controller logs** for backoff messages and error patterns
+2. **Monitor cluster resource usage** - high CPU/memory on control plane nodes
+3. **Review etcd metrics** if available (latency, request rate)
+4. **Consider scaling down** other controllers or reducing their poll frequency during peak usage
+
+The rate limiting is automatic and doesn't require configuration changes. If issues persist, consider:
+* Reducing the number of monitored namespaces
+* Increasing control plane resources
+* Checking for other high-load controllers in the cluster

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,10 @@ meta:
 * metrics-server (a requirement of vpa)
 * golang 1.17+
 
+### Large Cluster Considerations
+
+For large clusters (1000+ namespaces or high workload density), Goldilocks includes automatic rate limiting and backoff mechanisms to prevent etcd timeouts and control plane pressure. The controller will automatically detect and adapt to control plane load without requiring additional configuration.
+
 ### Installing Vertical Pod Autoscaler
 
 There are multiple ways to install VPA for use with Goldilocks:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -34,30 +34,65 @@ import (
 	"github.com/fairwindsops/goldilocks/pkg/handler"
 	"github.com/fairwindsops/goldilocks/pkg/kube"
 	"github.com/fairwindsops/goldilocks/pkg/utils"
+	"github.com/fairwindsops/goldilocks/pkg/vpa"
 )
 
 // KubeResourceWatcher contains the informer that watches Kubernetes objects and the queue that processes updates.
 type KubeResourceWatcher struct {
-	kubeClient kubernetes.Interface
-	informer   cache.SharedIndexInformer
-	wq         workqueue.TypedRateLimitingInterface[any]
+	kubeClient         kubernetes.Interface
+	informer           cache.SharedIndexInformer
+	wq                 workqueue.TypedRateLimitingInterface[any]
+	lastWatchFailure   time.Time
+	watchFailureCount  int
+	controlPlanePause  time.Duration
+	eventProcessingErrors int    // Track consecutive event processing errors
+	lastEventError     time.Time // Track when the last event error occurred
+	lastInformerRestart time.Time // Track informer restarts
+	informerRestarts   int       // Count informer restarts
 }
 
 // Watch tells the KubeResourceWatcher to start waiting for events
 func (watcher *KubeResourceWatcher) Watch(term <-chan struct{}) {
-	klog.Infof("Starting watcher.")
+	// Determine current log level
+	logLevel := 0
+	for i := 10; i >= 0; i-- {
+		if klog.V(klog.Level(i)).Enabled() {
+			logLevel = i
+			break
+		}
+	}
+	klog.Infof("Starting goldilocks controller (log level V=%d)", logLevel)
 
 	defer watcher.wq.ShutDown()
 	defer rt.HandleCrash()
 
+	// Record this informer restart
+	watcher.recordInformerRestart()
+
+	// Check if we should pause due to recent control plane pressure OR frequent informer restarts
+	if watcher.shouldPauseForControlPlane() {
+		klog.Warningf("CONTROL PLANE BACKOFF: Pausing watcher startup for %v due to control plane pressure (failure #%d, informer restarts #%d)", 
+			watcher.controlPlanePause, watcher.watchFailureCount, watcher.informerRestarts)
+		time.Sleep(watcher.controlPlanePause)
+		klog.Warningf("CONTROL PLANE BACKOFF: Resuming watcher startup after %v pause", watcher.controlPlanePause)
+	}
+
 	go watcher.informer.Run(term)
 
 	if !cache.WaitForCacheSync(term, watcher.HasSynced) {
+		klog.Errorf("Cache sync timeout - this may indicate control plane pressure")
+		// Record this as a potential control plane pressure indicator
+		watcher.recordWatchFailure()
 		rt.HandleError(fmt.Errorf("timeout waiting for cache sync"))
 		return
 	}
 
 	klog.Infof("Watcher synced.")
+	
+	// Note: Watch stream errors from reflector.go are logged by client-go but don't trigger our backoff
+	// because they're handled internally by the reflector with its own retry logic
+	klog.V(1).Infof("Watch streams active - reflector errors visible in logs don't trigger backoff unless they cause downstream issues")
+	
 	wait.Until(watcher.waitForEvents, time.Second, term)
 }
 
@@ -78,13 +113,41 @@ func (watcher *KubeResourceWatcher) LastSyncResourceVersion() string {
 }
 
 func (watcher *KubeResourceWatcher) process(evt utils.Event) error {
+	// Check if we should pause due to recent control plane pressure
+	if watcher.shouldPauseForControlPlane() {
+		klog.Warningf("CONTROL PLANE BACKOFF: Pausing event processing for %v due to control plane pressure (failure #%d)", 
+			watcher.controlPlanePause, watcher.watchFailureCount)
+		time.Sleep(watcher.controlPlanePause)
+		klog.Warningf("CONTROL PLANE BACKOFF: Resuming event processing after %v pause", watcher.controlPlanePause)
+		// Reset the pause after using it to avoid repeated pauses for the same failure
+		watcher.controlPlanePause = 0
+	}
+
 	info, _, err := watcher.informer.GetIndexer().GetByKey(evt.Key)
 
 	if err != nil {
-		//TODO - need some better error handling here
+		// Enhanced error handling for better debugging
+		klog.Errorf("Error getting object by key %s: %v", evt.Key, err)
+		
+		// Check if this is a control plane pressure related error (but not RBAC)
+		if utils.IsRetryableError(err) && !utils.IsRBACError(err) {
+			watcher.recordWatchFailure()
+		}
+		
 		return err
 	}
 
+	// For namespace events that might trigger reconciliation, wait for any active reconciliation to complete
+	if evt.ResourceType == "namespace" && (evt.EventType == "create" || evt.EventType == "update") {
+		reconciler := vpa.GetInstance()
+		if reconciler.IsReconciliationInProgress() {
+			klog.V(3).Infof("Waiting for active reconciliation to complete before processing %s event for %s", evt.EventType, evt.Key)
+			reconciler.WaitForReconciliationToComplete()
+			klog.V(3).Infof("Active reconciliation completed, now processing %s event for %s", evt.EventType, evt.Key)
+		}
+	}
+
+	// Process the event with improved error handling
 	handler.OnUpdate(info, evt)
 	return nil
 }
@@ -99,16 +162,34 @@ func (watcher *KubeResourceWatcher) next() bool {
 	defer watcher.wq.Done(evt)
 	processErr := watcher.process(evt.(utils.Event))
 	if processErr != nil {
-		// limit the number of retries
-		if watcher.wq.NumRequeues(evt) < 5 {
-			klog.Errorf("Error running queued item %s: %v", evt.(utils.Event).Key, processErr)
-			klog.Infof("Retry processing item %s", evt.(utils.Event).Key)
+		// Handling etcd pressure
+		numRequeues := watcher.wq.NumRequeues(evt)
+		maxRetries := 5
+
+		if numRequeues < maxRetries {
+			klog.Errorf("Error running queued item %s (attempt %d/%d): %v", evt.(utils.Event).Key, numRequeues+1, maxRetries, processErr)
+			if utils.IsRetryableError(processErr) {
+				klog.Infof("Detected retryable error for item %s, will retry with backoff", evt.(utils.Event).Key)
+				// Record this as a potential control plane pressure indicator (but not RBAC errors)
+				if !utils.IsRBACError(processErr) {
+					watcher.recordWatchFailure()
+					watcher.recordEventProcessingError()
+				}
+			} else {
+				klog.Infof("Retrying processing item %s", evt.(utils.Event).Key)
+				watcher.recordEventProcessingError()
+			}
 			watcher.wq.AddRateLimited(evt)
 		} else {
-			klog.Errorf("Giving up trying to run queued item %s: %v", evt.(utils.Event).Key, processErr)
+			klog.Errorf("Giving up trying to run queued item %s after %d attempts: %v", evt.(utils.Event).Key, maxRetries, processErr)
 			watcher.wq.Forget(evt)
+			watcher.recordEventProcessingError()
 			rt.HandleError(processErr)
 		}
+	} else {
+		// Success - reset error counters and forget the item to reset rate limiting
+		watcher.resetEventProcessingErrors()
+		watcher.wq.Forget(evt)
 	}
 	return true
 }
@@ -122,10 +203,14 @@ func NewController(stop <-chan bool) {
 	PodInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return kubeClient.Client.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+				ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				return kubeClient.Client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kubeClient.Client.CoreV1().Pods("").Watch(context.TODO(), metav1.ListOptions{})
+				ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				return kubeClient.Client.CoreV1().Pods("").Watch(ctx, metav1.ListOptions{})
 			},
 		},
 		&corev1.Pod{},
@@ -142,10 +227,14 @@ func NewController(stop <-chan bool) {
 	NSInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return kubeClient.Client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+				ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				return kubeClient.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kubeClient.Client.CoreV1().Namespaces().Watch(context.TODO(), metav1.ListOptions{})
+				ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				return kubeClient.Client.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{})
 			},
 		},
 		&corev1.Namespace{},
@@ -175,7 +264,7 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 			var err error
 			evt.Key, err = cache.MetaNamespaceKeyFunc(obj)
 			if err != nil {
-				klog.Errorf("Error handling add event")
+				klog.Errorf("Error handling add event: failed to get key for object %T: %v", obj, err)
 				return
 			}
 			evt.EventType = "create"
@@ -187,9 +276,16 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 		DeleteFunc: func(obj interface{}) {
 			var evt utils.Event
 			var err error
+			
+			// Handle DeletedFinalStateUnknown objects
+			if deletedObj, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				klog.V(4).Infof("Handling DeletedFinalStateUnknown object, extracting original object")
+				obj = deletedObj.Obj
+			}
+			
 			evt.Key, err = cache.MetaNamespaceKeyFunc(obj)
 			if err != nil {
-				klog.Errorf("Error handling delete event")
+				klog.V(4).Infof("Cannot get key for deleted object %T, skipping: %v", obj, err)
 				return
 			}
 			evt.EventType = "delete"
@@ -203,7 +299,7 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 			var err error
 			evt.Key, err = cache.MetaNamespaceKeyFunc(new)
 			if err != nil {
-				klog.Errorf("Error handling update event")
+				klog.Errorf("Error handling update event: failed to get key for object %T: %v", new, err)
 				return
 			}
 			evt.EventType = "update"
@@ -223,6 +319,95 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 		informer:   informer,
 		wq:         wq,
 	}
+}
+
+// shouldPauseForControlPlane determines if we should pause due to recent watch failures OR frequent informer restarts
+func (watcher *KubeResourceWatcher) shouldPauseForControlPlane() bool {
+	// Check for explicit watch failures first
+	if watcher.watchFailureCount > 0 {
+		// If it's been more than 5 minutes since last failure, reset the counter
+		if time.Since(watcher.lastWatchFailure) > 5*time.Minute {
+			watcher.watchFailureCount = 0
+			watcher.controlPlanePause = 0
+		} else if watcher.controlPlanePause > 0 {
+			return true
+		}
+	}
+	
+	// EXPLICIT BACKOFF: Treat ANY recent informer restart as control plane pressure
+	if watcher.informerRestarts >= 2 && time.Since(watcher.lastInformerRestart) < 5*time.Minute {
+		// Immediate exponential backoff: 2s, 4s, 8s, 16s, 30s (capped)
+		backoffSeconds := min(1<<(watcher.informerRestarts-1), 30)
+		watcher.controlPlanePause = time.Duration(backoffSeconds) * time.Second
+		klog.Warningf("EXPLICIT BACKOFF TRIGGERED: Control plane overloaded (%d restarts), pausing for %v", 
+			watcher.informerRestarts, watcher.controlPlanePause)
+		return true
+	}
+	
+	return false
+}
+
+// recordWatchFailure tracks watch stream failures and calculates exponential backoff
+func (watcher *KubeResourceWatcher) recordWatchFailure() {
+	watcher.lastWatchFailure = time.Now()
+	watcher.watchFailureCount++
+	
+	// Exponential backoff: 1s, 2s, 4s, 8s, 15s, 30s (capped at 30s)
+	backoffSeconds := 1 << min(watcher.watchFailureCount-1, 5) // 2^n but capped
+	if backoffSeconds > 30 {
+		backoffSeconds = 30
+	}
+	
+	watcher.controlPlanePause = time.Duration(backoffSeconds) * time.Second
+	
+	klog.Warningf("CONTROL PLANE PRESSURE DETECTED: Recorded watch failure #%d, will pause for %v on next operation", 
+		watcher.watchFailureCount, watcher.controlPlanePause)
+}
+
+// recordEventProcessingError tracks consecutive event processing errors
+func (watcher *KubeResourceWatcher) recordEventProcessingError() {
+	watcher.eventProcessingErrors++
+	watcher.lastEventError = time.Now()
+	
+	// If we're getting a lot of consecutive errors, this might indicate control plane pressure
+	if watcher.eventProcessingErrors >= 5 && time.Since(watcher.lastEventError) < 2*time.Minute {
+		klog.V(2).Infof("CONTROL PLANE PRESSURE DETECTED: %d consecutive event processing errors in recent period", 
+			watcher.eventProcessingErrors)
+		// Don't record a watch failure here as we may already have recorded it above
+		// Just log that we're seeing a pattern
+	}
+}
+
+// resetEventProcessingErrors resets the error counter after successful processing
+func (watcher *KubeResourceWatcher) resetEventProcessingErrors() {
+	if watcher.eventProcessingErrors > 0 {
+		klog.V(3).Infof("Event processing recovered after %d errors", watcher.eventProcessingErrors)
+		watcher.eventProcessingErrors = 0
+	}
+}
+
+// recordInformerRestart tracks when informers restart (indicating watch stream issues)
+func (watcher *KubeResourceWatcher) recordInformerRestart() {
+	now := time.Now()
+	
+	// If it's been more than 5 minutes since the last restart, reset the counter
+	if watcher.lastInformerRestart.IsZero() || time.Since(watcher.lastInformerRestart) > 5*time.Minute {
+		watcher.informerRestarts = 1
+	} else {
+		watcher.informerRestarts++
+	}
+	
+	watcher.lastInformerRestart = now
+	
+	klog.V(2).Infof("Informer restart #%d (watch stream restart detected)", watcher.informerRestarts)
+}
+
+// min returns the smaller of two integers (since Go doesn't have built-in min for int)
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func objectMeta(obj interface{}) metav1.ObjectMeta {

--- a/pkg/dashboard/namespace-list.go
+++ b/pkg/dashboard/namespace-list.go
@@ -1,9 +1,9 @@
 package dashboard
 
 import (
-	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/fairwindsops/goldilocks/pkg/kube"
 	"github.com/fairwindsops/goldilocks/pkg/utils"
@@ -27,7 +27,9 @@ func NamespaceList(opts Options) http.Handler {
 				}).String(),
 			}
 		}
-		namespacesList, err := kube.GetInstance().Client.CoreV1().Namespaces().List(context.TODO(), listOptions)
+		ctx, cancel := utils.CreateContextWithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		namespacesList, err := kube.GetInstance().Client.CoreV1().Namespaces().List(ctx, listOptions)
 		if err != nil {
 			klog.Errorf("Error getting namespace list: %v", err)
 			http.Error(w, "Error getting namespace list", http.StatusInternalServerError)

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -17,6 +17,7 @@ package summary
 import (
 	"context"
 	"strings"
+	"time"
 
 	controllerUtils "github.com/fairwindsops/controller-utils/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -282,7 +283,9 @@ func (s *Summarizer) updateVPAs() error {
 }
 
 func (s Summarizer) listVPAs(listOptions metav1.ListOptions) ([]vpav1.VerticalPodAutoscaler, error) {
-	vpas, err := s.vpaClient.Client.AutoscalingV1().VerticalPodAutoscalers(s.namespace).List(context.TODO(), listOptions)
+	ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	vpas, err := s.vpaClient.Client.AutoscalingV1().VerticalPodAutoscalers(s.namespace).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -15,11 +15,16 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestUniqueString(t *testing.T) {
@@ -120,4 +125,292 @@ var testFormatResourceCases = []struct {
 		resourceType: "memory",
 		expected:     "124M",
 	},
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      errors.New("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "context canceled",
+			err:      errors.New("context canceled"),
+			expected: true,
+		},
+		{
+			name:     "etcd connection error",
+			err:      errors.New("transport: authentication handshake failed: context canceled"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      errors.New("operation timeout"),
+			expected: true,
+		},
+		{
+			name:     "etcd error",
+			err:      errors.New("etcd server unavailable"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "kubernetes timeout error",
+			err:      kerrors.NewTimeoutError("operation timed out", 30),
+			expected: true,
+		},
+		{
+			name:     "kubernetes server timeout error",
+			err:      kerrors.NewServerTimeout(schema.GroupResource{Group: "", Resource: "pods"}, "list", 30),
+			expected: true,
+		},
+		{
+			name:     "kubernetes service unavailable error",
+			err:      kerrors.NewServiceUnavailable("service temporarily unavailable"),
+			expected: true,
+		},
+		{
+			name:     "kubernetes internal error",
+			err:      kerrors.NewInternalError(errors.New("internal server error")),
+			expected: true,
+		},
+		{
+			name:     "non-retryable error",
+			err:      kerrors.NewBadRequest("invalid request"),
+			expected: false,
+		},
+		{
+			name:     "watch stream decode error",
+			err:      errors.New("unable to decode an event from the watch stream: context canceled"),
+			expected: true,
+		},
+		{
+			name:     "watch stream error",
+			err:      errors.New("watch stream connection failed"),
+			expected: true,
+		},
+		{
+			name:     "too many requests error",
+			err:      errors.New("too many requests, please try again later"),
+			expected: true,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRetryableError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsRetryableError() = %v, want %v for error: %v", result, tt.expected, tt.err)
+			}
+		})
+	}
+}
+
+func TestRetryWithExponentialBackoff(t *testing.T) {
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		callCount := 0
+		operation := func(ctx context.Context) error {
+			callCount++
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := RetryWithExponentialBackoff(ctx, operation, "test operation")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callCount != 1 {
+			t.Errorf("Expected 1 call, got %d", callCount)
+		}
+	})
+
+	t.Run("succeeds after retries", func(t *testing.T) {
+		callCount := 0
+		operation := func(ctx context.Context) error {
+			callCount++
+			if callCount < 3 {
+				return errors.New("context deadline exceeded") // retryable error
+			}
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := RetryWithExponentialBackoff(ctx, operation, "test operation")
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callCount != 3 {
+			t.Errorf("Expected 3 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("fails with non-retryable error", func(t *testing.T) {
+		callCount := 0
+		expectedErr := kerrors.NewBadRequest("invalid request")
+		operation := func(ctx context.Context) error {
+			callCount++
+			return expectedErr
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := RetryWithExponentialBackoff(ctx, operation, "test operation")
+		if err != expectedErr {
+			t.Errorf("Expected %v, got %v", expectedErr, err)
+		}
+		if callCount != 1 {
+			t.Errorf("Expected 1 call, got %d", callCount)
+		}
+	})
+
+	t.Run("exhausts retries", func(t *testing.T) {
+		callCount := 0
+		operation := func(ctx context.Context) error {
+			callCount++
+			return errors.New("context deadline exceeded") // retryable error
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err := RetryWithExponentialBackoff(ctx, operation, "test operation")
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		// The exact number of retries depends on the backoff implementation
+		// We expect at least 3 attempts and at most 5
+		if callCount < 3 || callCount > 5 {
+			t.Errorf("Expected 3-5 calls, got %d", callCount)
+		}
+	})
+}
+
+func TestIsRBACError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "forbidden error",
+			err:      kerrors.NewForbidden(schema.GroupResource{Group: "", Resource: "pods"}, "test", errors.New("forbidden")),
+			expected: true,
+		},
+		{
+			name:     "unauthorized error",
+			err:      kerrors.NewUnauthorized("unauthorized"),
+			expected: true,
+		},
+		{
+			name:     "forbidden message",
+			err:      errors.New("clustertunnels.networking.cfargotunnel.com is forbidden: User \"system:serviceaccount:goldilocks:goldilocks-controller\" cannot list resource"),
+			expected: true,
+		},
+		{
+			name:     "controller-utils RBAC error",
+			err:      errors.New("forbidden: User \"system:serviceaccount:goldilocks:goldilocks-controller\" cannot list resource"),
+			expected: true,
+		},
+		{
+			name:     "cannot list resource",
+			err:      errors.New("cannot list resource \"clustertunnels\" in API group"),
+			expected: true,
+		},
+		{
+			name:     "serviceaccount error",
+			err:      errors.New("User \"system:serviceaccount:goldilocks:goldilocks-controller\" cannot access"),
+			expected: true,
+		},
+		{
+			name:     "non-RBAC error",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "timeout error",
+			err:      errors.New("context deadline exceeded"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRBACError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsRBACError() = %v, want %v for error: %v", result, tt.expected, tt.err)
+			}
+		})
+	}
+}
+
+func TestCreateContextWithTimeout(t *testing.T) {
+	t.Run("creates context with specified timeout", func(t *testing.T) {
+		parentCtx := context.Background()
+		timeout := 5 * time.Second
+
+		ctx, cancel := CreateContextWithTimeout(parentCtx, timeout)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("Expected context to have a deadline")
+		}
+
+		expectedDeadline := time.Now().Add(timeout)
+		if deadline.Before(expectedDeadline.Add(-time.Second)) || deadline.After(expectedDeadline.Add(time.Second)) {
+			t.Errorf("Deadline %v is not close to expected %v", deadline, expectedDeadline)
+		}
+	})
+
+	t.Run("uses default timeout for zero duration", func(t *testing.T) {
+		parentCtx := context.Background()
+		timeout := time.Duration(0)
+
+		ctx, cancel := CreateContextWithTimeout(parentCtx, timeout)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("Expected context to have a deadline")
+		}
+
+		expectedDeadline := time.Now().Add(30 * time.Second) // default timeout
+		if deadline.Before(expectedDeadline.Add(-time.Second)) || deadline.After(expectedDeadline.Add(time.Second)) {
+			t.Errorf("Deadline %v is not close to expected default %v", deadline, expectedDeadline)
+		}
+	})
 }

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -19,11 +19,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/samber/lo"
 	"k8s.io/client-go/util/retry"
+	"golang.org/x/time/rate"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 
@@ -53,6 +57,11 @@ type Reconciler struct {
 	IncludeNamespaces     []string
 	ExcludeNamespaces     []string
 	IgnoreControllerKind  []string
+	operationMutex        sync.Mutex     // Protects bulk operations
+	operationSemaphore    chan struct{}  // Limits concurrent VPA operations
+	activeOperationsWG    sync.WaitGroup // Tracks active VPA operations
+	reconciliationMutex   sync.RWMutex   // Coordinates between reconciliation and new events
+	rateLimiter           *rate.Limiter  // Limits control plane API calls to 10/second
 }
 
 type Controller struct {
@@ -65,6 +74,20 @@ type Controller struct {
 var singleton *Reconciler
 var controllerUtilsLogr = textlogger.NewLogger(textlogger.NewConfig())
 
+// getControlPlaneRateLimit returns the rate limit for control plane API calls from environment variable
+// Defaults to 10 calls per second if not set or invalid
+func getControlPlaneRateLimit() rate.Limit {
+	if rateLimitStr := os.Getenv("GOLDILOCKS_CONTROL_PLANE_RATE_LIMIT"); rateLimitStr != "" {
+		if rateLimit, err := strconv.ParseFloat(rateLimitStr, 64); err == nil && rateLimit > 0 {
+			klog.Infof("🏃 Control plane rate limit set to %.1f calls/second via GOLDILOCKS_CONTROL_PLANE_RATE_LIMIT", rateLimit)
+			return rate.Limit(rateLimit)
+		}
+		klog.Warningf("Invalid GOLDILOCKS_CONTROL_PLANE_RATE_LIMIT value '%s', using default 10 calls/second", rateLimitStr)
+	}
+	klog.Infof("🏃 Control plane rate limit set to default 10 calls/second")
+	return 10
+}
+
 // GetInstance returns a Reconciler singleton
 func GetInstance() *Reconciler {
 	if singleton == nil {
@@ -73,6 +96,8 @@ func GetInstance() *Reconciler {
 			VPAClient:             kube.GetVPAInstance(),
 			DynamicClient:         kube.GetDynamicInstance(),
 			ControllerUtilsClient: kube.GetControllerUtilsInstance(),
+			operationSemaphore:    make(chan struct{}, 3), // Allow max 3 concurrent VPA operations
+			rateLimiter:           rate.NewLimiter(getControlPlaneRateLimit(), 1), // Configurable rate limit, burst of 1
 		}
 	}
 	return singleton
@@ -85,14 +110,31 @@ func SetInstance(k8s *kube.ClientInstance, vpa *kube.VPAClientInstance, dynamic 
 		VPAClient:             vpa,
 		DynamicClient:         dynamic,
 		ControllerUtilsClient: controller,
+		operationSemaphore:    make(chan struct{}, 3), // Allow max 3 concurrent VPA operations
+		rateLimiter:           rate.NewLimiter(getControlPlaneRateLimit(), 1), // Configurable rate limit, burst of 1
 	}
 	return singleton
 }
 
 // ReconcileNamespace makes a vpa for every pod controller type in the namespace.
-func (r Reconciler) ReconcileNamespace(namespace *corev1.Namespace) error {
+func (r *Reconciler) ReconcileNamespace(namespace *corev1.Namespace) error {
+	// Acquire a write lock to prevent new events from being processed during reconciliation
+	r.reconciliationMutex.Lock()
+	defer r.reconciliationMutex.Unlock()
+	
+	// Wait for any ongoing VPA operations to complete before starting new reconciliation
+	r.activeOperationsWG.Wait()
+	
+	// Acquire the mutex to prevent concurrent bulk operations that could overwhelm etcd
+	r.operationMutex.Lock()
+	defer r.operationMutex.Unlock()
+
 	controllerLog.SetLogger(controllerUtilsLogr)
 	nsName := namespace.Name
+	
+	
+	klog.V(2).Infof("Starting reconciliation for namespace/%s", nsName)
+	
 	vpas, err := r.listVPAs(nsName)
 	if err != nil {
 		klog.Error(err.Error())
@@ -108,29 +150,61 @@ func (r Reconciler) ReconcileNamespace(namespace *corev1.Namespace) error {
 
 	controllers, err := r.listControllers(nsName)
 	if err != nil {
-		klog.Error(err.Error())
-		return err
+		// Check if this is an RBAC error - just log and continue with empty list
+		if utils.IsRBACError(err) {
+			klog.V(2).Infof("RBAC permissions prevent controller discovery in namespace %s: %v", nsName, err)
+			// Continue with empty controller list - we can still clean up existing VPAs
+			controllers = []Controller{}
+		} else {
+			klog.Error(err.Error())
+			return err
+		}
+	}
+	
+	// Add debug logging to understand what's happening with cloudflare-operator-system
+	if nsName == "cloudflare-operator-system" {
+		klog.V(3).Infof("🔍 DEBUG: cloudflare-operator-system processed - found %d controllers, error: %v", len(controllers), err)
 	}
 
-	return r.reconcileControllersAndVPAs(namespace, vpas, controllers)
+	err = r.reconcileControllersAndVPAs(namespace, vpas, controllers)
+	if err != nil {
+		return err
+	}
+	
+	// Wait for all VPA operations started during this reconciliation to complete
+	r.activeOperationsWG.Wait()
+	
+	klog.V(2).Infof("Completed reconciliation for namespace/%s with all VPA operations finished", nsName)
+	return nil
 }
 
-func (r Reconciler) cleanUpManagedVPAsInNamespace(namespace string, vpas []vpav1.VerticalPodAutoscaler) error {
+func (r *Reconciler) cleanUpManagedVPAsInNamespace(namespace string, vpas []vpav1.VerticalPodAutoscaler) error {
 	if len(vpas) < 1 {
 		klog.V(4).Infof("No goldilocks managed VPAs found in Namespace/%s, skipping cleanup", namespace)
 		return nil
 	}
 	klog.Infof("Deleting all goldilocks managed VPAs in Namespace/%s", namespace)
 	for _, vpa := range vpas {
+		// Track this operation in the wait group
+		r.activeOperationsWG.Add(1)
+		
+		// Acquire semaphore to limit concurrent VPA operations
+		r.operationSemaphore <- struct{}{}
 		err := r.deleteVPA(vpa)
+		<-r.operationSemaphore // Release semaphore
+		
+		// Mark this operation as complete
+		r.activeOperationsWG.Done()
+		
 		if err != nil {
 			return err
 		}
+		
 	}
 	return nil
 }
 
-func (r Reconciler) namespaceIsManaged(namespace *corev1.Namespace) bool {
+func (r *Reconciler) namespaceIsManaged(namespace *corev1.Namespace) bool {
 	for k, v := range namespace.Labels {
 		klog.V(4).Infof("Namespace/%s found label: %s=%s", namespace.Name, k, v)
 		if strings.ToLower(k) != utils.VpaEnabledLabel {
@@ -159,7 +233,7 @@ func (r Reconciler) namespaceIsManaged(namespace *corev1.Namespace) bool {
 	return r.OnByDefault
 }
 
-func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpav1.VerticalPodAutoscaler, controllers []Controller) error {
+func (r *Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpav1.VerticalPodAutoscaler, controllers []Controller) error {
 	defaultUpdateMode, _ := vpaUpdateModeForResource(ns)
 	defaultResourcePolicy, _ := vpaResourcePolicyForResource(ns)
 	defaultMinReplicas, _ := vpaMinReplicasForResource(ns)
@@ -189,27 +263,51 @@ func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpa
 			vpaName = cvpa.Name
 		}
 		klog.V(2).Infof("Reconciling Namespace/%s for %s/%s with VPA/%s", ns.Name, controller.Kind, controller.Name, vpaName)
+		
+		// Track this operation in the wait group
+		r.activeOperationsWG.Add(1)
+		
+		// Acquire semaphore to limit concurrent VPA operations
+		r.operationSemaphore <- struct{}{}
 		err := r.reconcileControllerAndVPA(ns, controller, cvpa, defaultUpdateMode, defaultResourcePolicy, defaultMinReplicas)
+		<-r.operationSemaphore // Release semaphore
+		
+		// Mark this operation as complete
+		r.activeOperationsWG.Done()
+		
 		if err != nil {
 			return err
 		}
+		
 	}
 
 	for _, vpa := range vpas {
 		if !vpaHasAssociatedController[vpa.Name] {
 			// these vpas do not have a matching controller, delete them
 			klog.V(2).Infof("Deleting dangling VPA/%s in Namespace/%s", vpa.Name, ns.Name)
+			
+			// Track this operation in the wait group
+			r.activeOperationsWG.Add(1)
+			
+			// Acquire semaphore to limit concurrent VPA operations
+			r.operationSemaphore <- struct{}{}
 			err := r.deleteVPA(vpa)
+			<-r.operationSemaphore // Release semaphore
+			
+			// Mark this operation as complete
+			r.activeOperationsWG.Done()
+			
 			if err != nil {
 				return err
 			}
+			
 		}
 	}
 
 	return nil
 }
 
-func (r Reconciler) reconcileControllerAndVPA(ns *corev1.Namespace, controller Controller, vpa *vpav1.VerticalPodAutoscaler, vpaUpdateMode *vpav1.UpdateMode, vpaResourcePolicy *vpav1.PodResourcePolicy, minReplicas *int32) error {
+func (r *Reconciler) reconcileControllerAndVPA(ns *corev1.Namespace, controller Controller, vpa *vpav1.VerticalPodAutoscaler, vpaUpdateMode *vpav1.UpdateMode, vpaResourcePolicy *vpav1.PodResourcePolicy, minReplicas *int32) error {
 	controllerObj := controller.Unstructured.DeepCopyObject()
 	if vpaUpdateModeOverride, explicit := vpaUpdateModeForResource(controllerObj); explicit {
 		vpaUpdateMode = vpaUpdateModeOverride
@@ -242,8 +340,16 @@ func (r Reconciler) reconcileControllerAndVPA(ns *corev1.Namespace, controller C
 	return nil
 }
 
-func (r Reconciler) listControllers(namespace string) ([]Controller, error) {
+func (r *Reconciler) listControllers(namespace string) ([]Controller, error) {
 	controllers := []Controller{}
+	
+	// Rate limit this API call
+	ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.waitForRateLimit(ctx, fmt.Sprintf("list controllers in %s", namespace)); err != nil {
+		return nil, err
+	}
+	
 	allTopControllers, err := r.ControllerUtilsClient.Client.GetAllTopControllersSummary(namespace)
 	if err != nil {
 		return nil, err
@@ -266,11 +372,26 @@ func (r Reconciler) listControllers(namespace string) ([]Controller, error) {
 	return controllers, nil
 }
 
-func (r Reconciler) listVPAs(namespace string) ([]vpav1.VerticalPodAutoscaler, error) {
+func (r *Reconciler) listVPAs(namespace string) ([]vpav1.VerticalPodAutoscaler, error) {
 	vpaListOptions := metav1.ListOptions{
 		LabelSelector: labels.Set(utils.VPALabels).String(),
 	}
-	existingVPAs, err := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(namespace).List(context.TODO(), vpaListOptions)
+
+	var existingVPAs *vpav1.VerticalPodAutoscalerList
+	ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Rate limit this API call
+	if err := r.waitForRateLimit(ctx, fmt.Sprintf("list VPAs in %s", namespace)); err != nil {
+		return nil, err
+	}
+	
+	err := utils.RetryWithExponentialBackoff(ctx, func(ctx context.Context) error {
+		var listErr error
+		existingVPAs, listErr = r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(namespace).List(ctx, vpaListOptions)
+		return listErr
+	}, fmt.Sprintf("list VPAs in namespace %s", namespace))
+
 	if err != nil {
 		return nil, err
 	}
@@ -285,25 +406,49 @@ func (r Reconciler) listVPAs(namespace string) ([]vpav1.VerticalPodAutoscaler, e
 	return existingVPAs.Items, nil
 }
 
-func (r Reconciler) deleteVPA(vpa vpav1.VerticalPodAutoscaler) error {
+func (r *Reconciler) deleteVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	if r.DryRun {
 		klog.Infof("Not deleting VPA/%s due to dryrun.", vpa.Name)
 		return nil
 	}
 
-	errDelete := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Delete(context.TODO(), vpa.Name, metav1.DeleteOptions{})
-	if errDelete != nil {
-		klog.Errorf("Error deleting VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, errDelete)
-		return errDelete
+	ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	
+	// Rate limit this API call
+	if err := r.waitForRateLimit(ctx, fmt.Sprintf("delete VPA %s/%s", vpa.Namespace, vpa.Name)); err != nil {
+		return err
+	}
+
+	err := utils.RetryWithExponentialBackoff(ctx, func(ctx context.Context) error {
+		return r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Delete(ctx, vpa.Name, metav1.DeleteOptions{})
+	}, fmt.Sprintf("delete VPA %s/%s", vpa.Namespace, vpa.Name))
+
+	if err != nil {
+		klog.Errorf("Error deleting VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, err)
+		return err
 	}
 	klog.Infof("Deleted VPA/%s in Namespace/%s", vpa.Name, vpa.Namespace)
 	return nil
 }
 
-func (r Reconciler) createVPA(vpa vpav1.VerticalPodAutoscaler) error {
+func (r *Reconciler) createVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	if !r.DryRun {
 		klog.V(9).Infof("Creating VPA/%s: %v", vpa.Name, vpa)
-		_, err := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Create(context.TODO(), &vpa, metav1.CreateOptions{})
+
+		ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		
+		// Rate limit this API call
+		if err := r.waitForRateLimit(ctx, fmt.Sprintf("create VPA %s/%s", vpa.Namespace, vpa.Name)); err != nil {
+			return err
+		}
+
+		err := utils.RetryWithExponentialBackoff(ctx, func(ctx context.Context) error {
+			_, createErr := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Create(ctx, &vpa, metav1.CreateOptions{})
+			return createErr
+		}, fmt.Sprintf("create VPA %s/%s", vpa.Namespace, vpa.Name))
+
 		if err != nil {
 			klog.Errorf("Error creating VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, err)
 			return err
@@ -315,21 +460,34 @@ func (r Reconciler) createVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	return nil
 }
 
-func (r Reconciler) updateVPA(vpa vpav1.VerticalPodAutoscaler) error {
+func (r *Reconciler) updateVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	if !r.DryRun {
 		klog.V(9).Infof("Updating VPA/%s: %v", vpa.Name, vpa)
-		// attempt to update the vpa using retries and backoffs
-		// [See: https://github.com/kubernetes/client-go/blob/master/examples/create-update-delete-deployment/main.go#L125]
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			// Note: Normally we're supposed to be getting the current VPA object, then updating that object between
-			//       each retry attempt, but since goldilocks should be the only controller that is manipulating
-			//       these VPA objects then it's safe to use the desired VPA that is originally passed to this function.
-			_, err := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Update(context.TODO(), &vpa, metav1.UpdateOptions{})
+
+		ctx, cancel := utils.CreateContextWithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		
+		// Rate limit this API call
+		if err := r.waitForRateLimit(ctx, fmt.Sprintf("update VPA %s/%s", vpa.Namespace, vpa.Name)); err != nil {
 			return err
-		})
-		if retryErr != nil {
-			klog.Errorf("Error updating VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, retryErr)
+		}
+
+		// Use enhanced retry with exponential backoff for etcd failures
+		err := utils.RetryWithExponentialBackoff(ctx, func(ctx context.Context) error {
+			// For conflict errors, use the original retry logic
+			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				// Note: Normally we're supposed to be getting the current VPA object, then updating that object between
+				//       each retry attempt, but since goldilocks should be the only controller that is manipulating
+				//       these VPA objects then it's safe to use the desired VPA that is originally passed to this function.
+				_, updateErr := r.VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Update(ctx, &vpa, metav1.UpdateOptions{})
+				return updateErr
+			})
 			return retryErr
+		}, fmt.Sprintf("update VPA %s/%s", vpa.Namespace, vpa.Name))
+
+		if err != nil {
+			klog.Errorf("Error updating VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, err)
+			return err
 		}
 		klog.V(2).Infof("Updated VPA/%s in Namespace/%s", vpa.Name, vpa.Namespace)
 	} else {
@@ -338,7 +496,7 @@ func (r Reconciler) updateVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	return nil
 }
 
-func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *corev1.Namespace, controller Controller, updateMode *vpav1.UpdateMode, resourcePolicy *vpav1.PodResourcePolicy, minReplicas *int32) vpav1.VerticalPodAutoscaler {
+func (r *Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *corev1.Namespace, controller Controller, updateMode *vpav1.UpdateMode, resourcePolicy *vpav1.PodResourcePolicy, minReplicas *int32) vpav1.VerticalPodAutoscaler {
 	var desiredVPA vpav1.VerticalPodAutoscaler
 
 	// create a brand new vpa with the correct information
@@ -456,4 +614,38 @@ func vpaMinReplicasForResource(obj runtime.Object) (*int32, bool) {
 	minReplicasInt32 := int32(minReplicas)
 
 	return &minReplicasInt32, explicit
+}
+
+// IsReconciliationInProgress returns true if VPA reconciliation is currently active
+func (r *Reconciler) IsReconciliationInProgress() bool {
+	// Try to acquire a read lock - if we can't, reconciliation is in progress
+	acquired := r.reconciliationMutex.TryRLock()
+	if acquired {
+		r.reconciliationMutex.RUnlock()
+		return false
+	}
+	return true
+}
+
+// WaitForReconciliationToComplete blocks until any active reconciliation completes
+func (r *Reconciler) WaitForReconciliationToComplete() {
+	// Acquire and immediately release a read lock to wait for active reconciliation
+	r.reconciliationMutex.RLock()
+	r.reconciliationMutex.RUnlock()
+}
+
+
+// shouldSlowDownForControlPlane checks if we should slow down VPA operations due to control plane pressure
+func (r *Reconciler) shouldSlowDownForControlPlane() bool {
+	// ALWAYS slow down - the control plane is already overloaded
+	return true
+}
+
+// waitForRateLimit enforces the 10 calls/second rate limit for control plane operations
+func (r *Reconciler) waitForRateLimit(ctx context.Context, operation string) error {
+	if err := r.rateLimiter.Wait(ctx); err != nil {
+		klog.V(3).Infof("⏳ RATE LIMIT: %s operation delayed due to rate limiting: %v", operation, err)
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

We've been seeing timeouts and errors in Goldilocks due to the way AWS EKS control plane handles spiking and autoscaling. When we have lot of VPA objects, the EKS control plane cannot handle the constant requests from the Goldilocks controller.  Logs for this show up as `retrying of unary invoker failed` trying to connect to ETCd from the Kubernetes API and in Goldilocks as `Failed to store checkpoints. Reason: context deadline exceeded`. When Goldilocks is not able to store VPA changes, the next loop causes VPA to do all of the same work again.  In our experience, VPA starts kicking every changed deployment roughly every 30 seconds. This PR strives to improve the Goldilocks controller response to ETCd timeouts and control plane pressure. It watches for errors from the control plane, and backs off to let ETCd recover. There's also now a global rate limit to help keep the controller more consistent.

### What changes did you make?

Enhanced Controller Resilience:
    - Exponential backoff for watch stream failures and informer restarts
    - Control plane pressure detection with automatic pausing
    - Timeout handling for Kubernetes API calls
    - Classify retryable vs non retryable errors for logging
  2. Rate Limiting Improvements:
    - Implemented intelligent backoff (1s, 2s, 4s, 8s, 15s, 30s max) for etcd related issues
    - Added explicit backoff triggers for frequent informer restarts (≥2 restarts in 5 minutes)
    - Handle the DeletedFinalStateUnknown objects in event processing
  3. VPA Reconciliation Coordination:
    - Reconciliation loops complete fully to reduce control plane load
  4. Enhanced Error Handling:
    - Identify RBAC vs. control plane errors
    - Log timeouts with context and retry attempt counts
    - Add exponential backoff retry for API operations
  5. Timeout Management:
    - Add the timeout contexts! It fit with the rest of the project :)
    - Try to handle timeouts more consistently instead of spamming retries at a failing control plane

### What alternative solution should we consider, if any?

A global rate limit only - this would be simpler but less intelligent than the current approach which dynamically adjusts based on control plane health indicators and error patterns.

I set a reasonable default, but the rate limit is also configurable so we can scale Goldilocks properly in each cluster.